### PR TITLE
chore: markdownlint-cli2 設定を追加 (#9)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "MD013": {
+      "line_length": 200,
+      "code_blocks": false,
+      "tables": false
+    },
+    "MD024": false,
+    "MD029": false,
+    "MD036": false,
+    "MD040": false,
+    "MD041": false,
+    "MD060": false
+  },
+  "globs": [
+    "*.md",
+    "docs/**/*.md",
+    ".github/**/*.md"
+  ],
+  "ignores": [
+    ".tmp/**",
+    "node_modules/**"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ becky のポートフォリオサイト。GitHub Pages で公開。
 
 - Git 運用: [Git 運用ルール](docs/git-workflow.md)（main 単独 + PR 必須）
 
+### ドキュメント lint
+
+- 設定ファイル: [`.markdownlint-cli2.jsonc`](.markdownlint-cli2.jsonc)
+- ローカル実行: `npx markdownlint-cli2` または `/doc-lint` スキル
+- CI / pre-commit での自動実行は設定していない
+
 ## 演出
 
 ### 時間帯連動ヘッダー


### PR DESCRIPTION
## 概要

ドキュメント追加・編集時のスタイル違反を未然に防ぐため、リポジトリに markdownlint-cli2 設定を配置する。PR #8 時にデフォルトルールで 27 件警告が出た手戻りの再発防止。

## 変更内容

- `.markdownlint-cli2.jsonc` を追加（他リポ agent-commons / rag-knowledge / ai-assistant / shared-workflows と同じ共通設定）
  - MD013: line_length=200, code_blocks=false, tables=false
  - MD024 / MD029 / MD036 / MD040 / MD041 / MD060 を無効化
  - globs: `*.md`, `docs/**/*.md`, `.github/**/*.md`
  - ignores: `.tmp/**`, `node_modules/**`
- README.md に「ドキュメント lint」サブセクションを追加（設定ファイル参照・ローカル実行手順・CI/pre-commit 不採用方針）

## 動作確認

- [x] `npx markdownlint-cli2` を実行し、既存 4 ファイル（README.md / CLAUDE.md / docs/git-workflow.md / .github/pull_request_template.md）で 0 件
- [ ] PC ブラウザで確認（lint 設定追加のためサイト動作影響なし）
- [ ] ローカルサーバー（`python -m http.server` + LAN IP）経由で確認（同上）
- [ ] スマホ実機で確認（同上）
- [ ] `?debug=1` で時間帯演出を確認（同上）

## 関連 Issue

Closes #9