### PR TITLE
feat(screenshot): 汎用ヘッドレス Chrome スクリーンショット撮影スクリプトを追加 (#5)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# シェルスクリプトは Git Bash / Linux / macOS で実行されるため必ず LF を維持する
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ __pycache__/
 
 # Claude Code /auto-finalize 認可フラグ
 .pr-creation-authorized
+
+# Claude Code /aidlc / /plan-work 一時ドキュメント
+aidlc-docs/
+aidlc-archive/

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ becky のポートフォリオサイト。GitHub Pages で公開。
 
 ## ファイル構成
 
-| ファイル | 説明 |
+| ファイル / ディレクトリ | 説明 |
 | --- | --- |
 | `index.html` | エントリポイント。About / Experience / Works / Contact の4タブ構成 |
 | `style.css` | スタイル定義（デザイントークン・時間帯演出・アバターアニメ含む） |
 | `script.js` | タブ切替・アバター操作・時間帯判定・デバッグUI |
 | `favicon.svg` | サイトアイコン |
+| `tools/` | 開発補助スクリプト（サイト本体には含まれない） |
 
 ビルドステップなし。HTML/CSS/JS をそのまま GitHub Pages から配信。
 
@@ -24,6 +25,59 @@ becky のポートフォリオサイト。GitHub Pages で公開。
 - 設定ファイル: [`.markdownlint-cli2.jsonc`](.markdownlint-cli2.jsonc)
 - ローカル実行: `npx markdownlint-cli2` または `/doc-lint` スキル
 - CI / pre-commit での自動実行は設定していない
+
+### スクリーンショット撮影
+
+ヘッドレス Chrome で任意の URL を撮影する汎用スクリプト。UI 試行錯誤時の繰り返し作業を想定。
+本サイト固有のロジックは持たないため、他プロジェクトでも流用可能。
+
+- スクリプト: [`tools/screenshot.sh`](tools/screenshot.sh)
+- 前提: Google Chrome または Chromium がインストール済みであること。Bash 実行環境（Windows では Git Bash 等）
+
+Chrome 実行ファイルは `CHROME` 環境変数 / `PATH` / Windows 既定インストール先 / macOS 既定インストール先の順で自動検出する。検出に失敗した場合は `--chrome <PATH>` で明示指定する。
+
+#### 使い方
+
+```bash
+# 単発撮影 → .tmp/screenshots/<yyyyMMdd_HHmmss>.png
+tools/screenshot.sh https://becky3.github.io/
+
+# ファイル名指定 → .tmp/screenshots/homepage.png
+tools/screenshot.sh --name homepage https://becky3.github.io/
+
+# 一括撮影（時間帯 6 種）→ .tmp/screenshots/<timestamp>_<name>.png
+tools/screenshot.sh \
+  --names early-morning,forenoon,afternoon,evening,night,late-night \
+  "https://becky3.github.io/?band=early-morning" \
+  "https://becky3.github.io/?band=forenoon" \
+  "https://becky3.github.io/?band=afternoon" \
+  "https://becky3.github.io/?band=evening" \
+  "https://becky3.github.io/?band=night" \
+  "https://becky3.github.io/?band=late-night"
+```
+
+#### オプション
+
+| オプション | 既定値 | 説明 |
+| --- | --- | --- |
+| `-o`, `--output-dir <DIR>` | `.tmp/screenshots` | 出力ディレクトリ |
+| `-n`, `--name <NAME>` | timestamp | 単発撮影時のファイル名（拡張子なし）。`[A-Za-z0-9._-]` のみ許可。複数 URL 時はエラー |
+| `--names <N1,N2,...>` | （連番） | 一括撮影時のファイル名サフィックス。URL 数と一致 + 重複禁止。文字制約は `--name` と同じ |
+| `-w`, `--viewport <WxH>` | `1280x800` | ビューポートサイズ |
+| `-t`, `--virtual-time-budget <MS>` | `4000` | フォント・画像読み込み待機 ms |
+| `--no-sandbox` | 無効 | Chrome に `--no-sandbox` を付与（Linux / CI 環境向け、opt-in） |
+| `--chrome <PATH>` | 自動検出 | Chrome 実行ファイルパス（`CHROME` 環境変数も可） |
+
+ファイル名規則:
+
+| モード | 既定 | `--name` / `--names` 指定時 |
+| --- | --- | --- |
+| 単発 (URL 1 件) | `<timestamp>.png` | `<NAME>.png` |
+| 一括 (URL N 件) | `<timestamp>_<index>.png`（1 始まり） | `<timestamp>_<NAME>.png` |
+
+timestamp フォーマット: `yyyyMMdd_HHmmss`。
+
+一括撮影は fail-fast。1 件失敗した時点で残りの URL は撮影せずに終了する。撮影済みファイルはそのまま残る。
 
 ## 演出
 

--- a/tools/screenshot.sh
+++ b/tools/screenshot.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# 汎用 headless Chrome スクリーンショット撮影スクリプト。
+# 既知のハマりポイント（絶対パス・URL hash・virtual-time-budget・実行ファイル解決）を
+# デフォルトで解消する。
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: tools/screenshot.sh [options] URL [URL ...]
+
+Options:
+  -o, --output-dir DIR           Output directory (default: .tmp/screenshots)
+  -n, --name NAME                Filename for single URL mode (without extension)
+                                 Allowed characters: [A-Za-z0-9._-]
+      --names NAME1,NAME2,...    Per-URL filename suffixes for batch mode
+                                 (count must match URL count, must be unique,
+                                  same character set as --name)
+  -w, --viewport WIDTHxHEIGHT    Viewport size (default: 1280x800)
+  -t, --virtual-time-budget MS   virtual-time-budget in ms (default: 4000)
+      --no-sandbox               Pass --no-sandbox to Chrome (Linux/CI only)
+      --chrome PATH              Override Chrome executable path
+                                 (env: CHROME also honored)
+  -h, --help                     Show this help
+
+Behavior:
+  Batch mode is fail-fast: aborts on the first screenshot failure.
+  Already-captured files in the same run are kept on disk.
+
+Filename rules:
+  Single URL, no --name:        <timestamp>.png
+  Single URL, --name NAME:      NAME.png
+  Multiple URLs, no --names:    <timestamp>_<index>.png   (1-origin index)
+  Multiple URLs, --names X,Y:   <timestamp>_X.png / <timestamp>_Y.png
+
+  timestamp format: yyyyMMdd_HHmmss
+
+Examples:
+  # Single shot to .tmp/screenshots/<timestamp>.png
+  tools/screenshot.sh https://example.com
+
+  # Single shot with custom name
+  tools/screenshot.sh --name homepage https://example.com
+
+  # Batch shot (6 time bands)
+  tools/screenshot.sh \
+    --names early-morning,forenoon,afternoon,evening,night,late-night \
+    "https://becky3.github.io/?band=early-morning" \
+    "https://becky3.github.io/?band=forenoon" \
+    "https://becky3.github.io/?band=afternoon" \
+    "https://becky3.github.io/?band=evening" \
+    "https://becky3.github.io/?band=night" \
+    "https://becky3.github.io/?band=late-night"
+EOF
+}
+
+detect_chrome() {
+  if [ -n "${CHROME:-}" ] && [ -x "$CHROME" ]; then
+    echo "$CHROME"
+    return
+  fi
+  for cmd in google-chrome google-chrome-stable chromium chromium-browser chrome; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      command -v "$cmd"
+      return
+    fi
+  done
+  for path in \
+    "/c/Program Files/Google/Chrome/Application/chrome.exe" \
+    "/c/Program Files (x86)/Google/Chrome/Application/chrome.exe" \
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"; do
+    if [ -x "$path" ]; then
+      echo "$path"
+      return
+    fi
+  done
+  echo ""
+}
+
+to_native_path() {
+  local p="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$p"
+  else
+    echo "$p"
+  fi
+}
+
+OUTPUT_DIR=".tmp/screenshots"
+NAME=""
+NAMES=""
+VIEWPORT="1280x800"
+VTB="4000"
+CHROME_PATH=""
+NO_SANDBOX=0
+URLS=()
+
+NAME_PATTERN='^[A-Za-z0-9._-]+$'
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o|--output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    -n|--name) NAME="$2"; shift 2 ;;
+    --names) NAMES="$2"; shift 2 ;;
+    -w|--viewport) VIEWPORT="$2"; shift 2 ;;
+    -t|--virtual-time-budget) VTB="$2"; shift 2 ;;
+    --no-sandbox) NO_SANDBOX=1; shift ;;
+    --chrome) CHROME_PATH="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; while [ $# -gt 0 ]; do URLS+=("$1"); shift; done ;;
+    -*) echo "ERROR: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) URLS+=("$1"); shift ;;
+  esac
+done
+
+if [ ${#URLS[@]} -eq 0 ]; then
+  echo "ERROR: at least one URL is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if ! [[ "$VIEWPORT" =~ ^[0-9]+x[0-9]+$ ]]; then
+  echo "ERROR: --viewport must be WIDTHxHEIGHT (e.g. 1280x800)" >&2
+  exit 2
+fi
+WIDTH="${VIEWPORT%x*}"
+HEIGHT="${VIEWPORT#*x}"
+
+if ! [[ "$VTB" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --virtual-time-budget must be a non-negative integer" >&2
+  exit 2
+fi
+
+if [ ${#URLS[@]} -gt 1 ] && [ -n "$NAME" ]; then
+  echo "ERROR: --name is for single URL mode. Use --names for multiple URLs." >&2
+  exit 2
+fi
+
+if [ -n "$NAME" ] && ! [[ "$NAME" =~ $NAME_PATTERN ]]; then
+  echo "ERROR: --name contains invalid characters: '$NAME' (allowed: [A-Za-z0-9._-])" >&2
+  exit 2
+fi
+
+NAMES_ARR=()
+if [ -n "$NAMES" ]; then
+  IFS=',' read -ra NAMES_ARR <<< "$NAMES"
+  if [ ${#URLS[@]} -ne ${#NAMES_ARR[@]} ]; then
+    echo "ERROR: --names count (${#NAMES_ARR[@]}) does not match URL count (${#URLS[@]})" >&2
+    exit 2
+  fi
+  for n in "${NAMES_ARR[@]}"; do
+    if ! [[ "$n" =~ $NAME_PATTERN ]]; then
+      echo "ERROR: --names entry contains invalid characters: '$n' (allowed: [A-Za-z0-9._-])" >&2
+      exit 2
+    fi
+  done
+  if [ "$(printf '%s\n' "${NAMES_ARR[@]}" | sort -u | wc -l)" -ne "${#NAMES_ARR[@]}" ]; then
+    echo "ERROR: --names entries must be unique (would overwrite output files)" >&2
+    exit 2
+  fi
+fi
+
+if [ -z "$CHROME_PATH" ]; then
+  CHROME_PATH="$(detect_chrome)"
+fi
+if [ -z "$CHROME_PATH" ]; then
+  echo "ERROR: Chrome not found. Set CHROME env var or pass --chrome PATH." >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR_ABS="$(cd "$OUTPUT_DIR" && pwd)"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+shoot() {
+  local url="$1" filename="$2"
+  local out_path="$OUTPUT_DIR_ABS/$filename"
+  local out_native
+  out_native="$(to_native_path "$out_path")"
+  echo "[shoot] $url -> $out_path"
+  local -a chrome_args=(
+    --headless=new
+    --disable-gpu
+    --hide-scrollbars
+    --virtual-time-budget="$VTB"
+    --window-size="$WIDTH,$HEIGHT"
+    --screenshot="$out_native"
+  )
+  if [ "$NO_SANDBOX" = "1" ]; then
+    chrome_args+=(--no-sandbox)
+  fi
+  "$CHROME_PATH" "${chrome_args[@]}" "$url" >/dev/null
+  if [ ! -f "$out_path" ]; then
+    echo "ERROR: screenshot file was not created: $out_path" >&2
+    return 1
+  fi
+}
+
+if [ ${#URLS[@]} -eq 1 ]; then
+  filename="${NAME:-$TIMESTAMP}.png"
+  shoot "${URLS[0]}" "$filename"
+else
+  for i in "${!URLS[@]}"; do
+    if [ -n "$NAMES" ]; then
+      suffix="${NAMES_ARR[$i]}"
+    else
+      suffix="$((i + 1))"
+    fi
+    filename="${TIMESTAMP}_${suffix}.png"
+    shoot "${URLS[$i]}" "$filename"
+  done
+fi
+
+echo "Done. Output: $OUTPUT_DIR_ABS"

--- a/tools/screenshot.sh
+++ b/tools/screenshot.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 # 汎用 headless Chrome スクリーンショット撮影スクリプト。
-# 既知のハマりポイント（絶対パス・URL hash・virtual-time-budget・実行ファイル解決）を
+# 既知のハマりポイント（絶対パス・virtual-time-budget・実行ファイル解決）を
 # デフォルトで解消する。
 set -euo pipefail
+
+# 値を取るオプション用に「次の引数があるか」を検査する。
+require_value() {
+  local opt="$1" remaining="$2"
+  if [ "$remaining" -lt 2 ]; then
+    echo "ERROR: option $opt requires a value" >&2
+    usage >&2
+    exit 2
+  fi
+}
 
 usage() {
   cat <<'EOF'
@@ -98,13 +108,13 @@ NAME_PATTERN='^[A-Za-z0-9._-]+$'
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    -o|--output-dir) OUTPUT_DIR="$2"; shift 2 ;;
-    -n|--name) NAME="$2"; shift 2 ;;
-    --names) NAMES="$2"; shift 2 ;;
-    -w|--viewport) VIEWPORT="$2"; shift 2 ;;
-    -t|--virtual-time-budget) VTB="$2"; shift 2 ;;
+    -o|--output-dir) require_value "$1" "$#"; OUTPUT_DIR="$2"; shift 2 ;;
+    -n|--name) require_value "$1" "$#"; NAME="$2"; shift 2 ;;
+    --names) require_value "$1" "$#"; NAMES="$2"; shift 2 ;;
+    -w|--viewport) require_value "$1" "$#"; VIEWPORT="$2"; shift 2 ;;
+    -t|--virtual-time-budget) require_value "$1" "$#"; VTB="$2"; shift 2 ;;
     --no-sandbox) NO_SANDBOX=1; shift ;;
-    --chrome) CHROME_PATH="$2"; shift 2 ;;
+    --chrome) require_value "$1" "$#"; CHROME_PATH="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [ $# -gt 0 ]; do URLS+=("$1"); shift; done ;;
     -*) echo "ERROR: unknown option: $1" >&2; usage >&2; exit 2 ;;


### PR DESCRIPTION
## 概要

UI 試行錯誤時に毎回手書きしていた `chrome --headless=new --screenshot=...` フローを汎用スクリプト化し、既知のハマりポイント（絶対パス・`--virtual-time-budget`・Chrome 実行ファイル解決）をデフォルトで解消する。

## 変更内容

- `tools/screenshot.sh` を新規追加
  - 単発撮影 / 一括撮影の両モード対応
  - デフォルト出力: `.tmp/screenshots/<yyyyMMdd_HHmmss>[_<variation>].png`
  - `--name` / `--names` でファイル名上書き可（`[A-Za-z0-9._-]+` のみ許可、`--names` は重複禁止）
  - `--virtual-time-budget=4000`、`--hide-scrollbars`、絶対パス変換、Chrome 自動検出をデフォルト挙動に組み込み
  - `--no-sandbox` は opt-in（Linux/CI 用途）
  - 一括撮影は fail-fast（最初の失敗で中断、撮影済みファイルは保持）
  - URL hash の自動除去はしない（ブラウザ仕様に応じた予期動作のため、Issue 本文から該当記述を削除）
- `README.md` に「スクリーンショット撮影」セクション追加（前提環境・使い方・オプション表・ファイル名規則）
- `.gitignore` に `aidlc-docs/` `aidlc-archive/` を追加
- `.gitattributes` を新規追加し `*.sh text eol=lf` で Bash スクリプトの LF 改行を保証

## 動作確認

- [x] 単発撮影成功 → `.tmp/screenshots/smoke-test.png`
- [x] 6 時間帯一括撮影成功 → 各バリエーションで朝焼け／青空／夕焼け／夜空などの演出が正しく描画されることを Read で視覚確認
- [x] バリデーション 4 ケース（path traversal / `/` 含む / 重複 / 未知オプション）すべて拒否を確認
- [x] markdownlint-cli2 通過（5 files / 0 errors）
- [x] `bash -n tools/screenshot.sh` 通過
- [ ] PC ブラウザで確認（サイト本体には影響しない補助スクリプトのため不要）

## 関連 Issue

Closes #5