### PR TITLE
feat: 早朝・夕方の太陽位置を低くして日の出/沈む夕日を表現 (#6)

### DIFF
--- a/style.css
+++ b/style.css
@@ -112,7 +112,7 @@ body[data-time-band="late-night"] {
   --header-social-border: rgba(255, 255, 255, 0.16);
 }
 
-/* 太陽（早朝〜夕方） — 月と同じ右上位置で色・縦位置を時間帯で変える */
+/* 太陽（早朝〜夕方） — 月と同じ右上位置で色・縦位置を時間帯で変える。早朝・夕方は「沈む夕日／日の出」表現のため下端基準（calc(100% - N)）で配置する */
 .sun {
   position: absolute;
   top: 26px;
@@ -130,7 +130,7 @@ body[data-time-band="late-night"] {
 body[data-time-band="early-morning"] .sun {
   opacity: 1;
   transform: translateY(0) scale(1);
-  top: 80px;
+  top: calc(100% - 80px);
   background: radial-gradient(circle at 35% 35%, #fff5d6 0%, #fdba74 65%, #fb923c 100%);
   box-shadow: 0 0 28px rgba(251, 146, 60, 0.5), 0 0 60px rgba(254, 215, 170, 0.4);
 }
@@ -154,7 +154,7 @@ body[data-time-band="afternoon"] .sun {
 body[data-time-band="evening"] .sun {
   opacity: 1;
   transform: translateY(0) scale(1);
-  top: 110px;
+  top: calc(100% - 22px);
   background: radial-gradient(circle at 35% 35%, #fde68a 0%, #fb7185 55%, #be123c 100%);
   box-shadow: 0 0 32px rgba(244, 63, 94, 0.55), 0 0 70px rgba(251, 113, 133, 0.4);
 }


### PR DESCRIPTION
## 概要

時間帯連動ヘッダー演出のうち、早朝・夕方の太陽位置を低くする。特に夕方はヘッダー矩形の下端で半分カットさせ「沈む夕日」を視覚的に表現する。

## 変更内容

- `style.css`: `body[data-time-band="early-morning"] .sun` の `top: 80px` → `top: calc(100% - 80px)`（地平線寄りで日の出感を強調）
- `style.css`: `body[data-time-band="evening"] .sun` の `top: 110px` → `top: calc(100% - 22px)`（22px = 太陽の半径。ヘッダー下端で半分カットされ沈む夕日として見える）
- `style.css`: `.sun` 直前のコメントを拡張し、早朝・夕方が下端基準（`calc(100% - N)`）で配置される意図を明記

`header.profile` は `position: relative; overflow: hidden;` のため、`top: calc(100% - N)` はヘッダー高さに対する下端基準として機能。ヘッダー高さがレスポンシブで変動しても下端からの距離が一定に保たれる。

## 動作確認

- [x] ローカルサーバー（`python -m http.server` + ヘッドレス Chrome）経由でスクリーンショット撮影し全 6 時間帯を目視確認
- [x] `?band=early-morning` / `?band=evening` で実装後の見え方を確認（早朝: 地平線寄りの低い位置で日の出感 / 夕方: ヘッダー下端で半分カットされ沈む夕日）
- [x] `?band=forenoon` / `?band=afternoon` / `?band=night` / `?band=late-night` で未変更時間帯の表示が保持されていることを確認
- [ ] PC ブラウザ実機で確認（未実施）
- [ ] スマホ実機で確認（未実施）

## 関連 Issue

Closes #6